### PR TITLE
TODO `_get_next_state` refinement

### DIFF
--- a/ftplugin/orgmode/liborgmode/base.py
+++ b/ftplugin/orgmode/liborgmode/base.py
@@ -34,11 +34,8 @@ def flatten_list(lst):
 		elif isinstance(item, collections.Iterable):
 			# yield from would be so nice... but c'est la vie
 			for val in item:
-				if isinstance(val, collections.Iterable):
-					for final in gen_lst(val):
-						yield final
-				else:
-					yield val
+				for final in gen_lst(val):
+					yield final
 		else:
 			yield item
 	return [i for i in gen_lst(lst)]

--- a/ftplugin/orgmode/plugins/Todo.py
+++ b/ftplugin/orgmode/plugins/Todo.py
@@ -89,13 +89,13 @@ class Todo(object):
 		if all_states is None:
 			raise PluginError(u"Empty TODO keyword list. Please examine `g/b:org_todo_keywords`")
 		cleaned_todos = [[
-			split_access_key(todo)[0] for todo in it.chain.from_iterable(x)] 
+			split_access_key(todo)[0] for todo in it.chain.from_iterable(x)]
 			for x in all_states] + [[None]]
 
 		flattened_todos = []
 		duplicate_marker = [
 			flattened_todos.append(todo_iter) if todo_iter not in
-			flattened_todos else True 
+			flattened_todos else True
 			for todo_iter in it.chain.from_iterable(cleaned_todos)]
 		if True in duplicate_marker:
 			raise PluginError(u"Duplicate name in TODO keyword list. Please examine `g/b:org_todo_keywords`")

--- a/ftplugin/orgmode/plugins/Todo.py
+++ b/ftplugin/orgmode/plugins/Todo.py
@@ -8,7 +8,7 @@ from orgmode import settings
 from orgmode.liborgmode.base import Direction
 from orgmode.menu import Submenu, ActionEntry
 from orgmode.keybinding import Keybinding, Plug
-from orgmode.exception import PluginError
+from orgmode.exceptions import PluginError
 
 # temporary todo states for differnent orgmode buffers
 ORGTODOSTATES = {}

--- a/ftplugin/orgmode/plugins/Todo.py
+++ b/ftplugin/orgmode/plugins/Todo.py
@@ -92,8 +92,12 @@ class Todo(object):
 			split_access_key(todo)[0] for todo in it.chain.from_iterable(x)] 
 			for x in all_states] + [[None]]
 
-		flattened_todos = list(it.chain.from_iterable(cleaned_todos))
-		if len(flattened_todos) != len(set(flattened_todos)):
+		flattened_todos = []
+		duplicate_marker = [
+			flattened_todos.append(todo_iter) if todo_iter not in
+			flattened_todos else True 
+			for todo_iter in it.chain.from_iterable(cleaned_todos)]
+		if True in duplicate_marker:
 			raise PluginError(u"Duplicate name in TODO keyword list. Please examine `g/b:org_todo_keywords`")
 		# TODO This is the case when there are 2 todo states with the same
 		# name. It should be handled by making a simple class to hold TODO
@@ -131,8 +135,9 @@ class Todo(object):
 		next_dir = -1 if direction == Direction.BACKWARD else 1
 		# work only with top level index
 		if next_set:
-			top_set = next((todo_set[0] for todo_set in enumerate(cleaned_todos)
-						    if current_state in todo_set[1]), -1)
+			top_set = next((
+				todo_set[0] for todo_set in enumerate(cleaned_todos)
+				if current_state in todo_set[1]), -1)
 			ind = (top_set + next_dir) % len(cleaned_todos)
 			if ind != len(cleaned_todos)-1:
 				echom("Using set: %s" % str(all_states[ind]))
@@ -141,8 +146,9 @@ class Todo(object):
 			return cleaned_todos[ind][0]
 		# No next set, cycle around everything
 		else:
-			ind = next((todo_iter[0] for todo_iter in enumerate(flattened_todos)
-					    if todo_iter[1] == current_state), -1)
+			ind = next((
+				todo_iter[0] for todo_iter in enumerate(flattened_todos)
+				if todo_iter[1] == current_state), -1)
 			return flattened_todos [(ind+next_dir)%len(flattened_todos)]
 
 	@classmethod

--- a/ftplugin/orgmode/plugins/Todo.py
+++ b/ftplugin/orgmode/plugins/Todo.py
@@ -136,12 +136,15 @@ class Todo(object):
 			if top_set is None:
 				return top_set
 			ind = (top_set + next_dir) % len(cleaned_todos)
-			echom("Using set: %s" % str(all_states[ind]))
+			if ind != len(cleaned_todos)-1:
+				echom("Using set: %s" % str(all_states[ind]))
+			else:
+				echom("Keyword removed.")
 			return cleaned_todos[ind][0]
 		# No next set, cycle around everything
 		else:
-			ind = next((todo_iter[0] for todo_iter in enumerate(current_state)
-					    if todo_iter[1] is current_state), None)
+			ind = next((todo_iter[0] for todo_iter in enumerate(flattened_todos)
+					    if todo_iter[1] == current_state), None)
 			if ind is None:
 				return ind
 			return flattened_todos [(ind+next_dir)%len(flattened_todos)]

--- a/ftplugin/orgmode/plugins/Todo.py
+++ b/ftplugin/orgmode/plugins/Todo.py
@@ -86,19 +86,13 @@ class Todo(object):
 			* no two state share a same name
 		"""
 		# TODO Write tests. -- Ron89
-		if all_states is None:
-			raise PluginError(u"Empty TODO keyword list. Please examine `g/b:org_todo_keywords`")
 		cleaned_todos = [[
 			split_access_key(todo)[0] for todo in it.chain.from_iterable(x)]
 			for x in all_states] + [[None]]
 
-		flattened_todos = []
-		duplicate_marker = [
-			flattened_todos.append(todo_iter) if todo_iter not in
-			flattened_todos else True
-			for todo_iter in it.chain.from_iterable(cleaned_todos)]
-		if True in duplicate_marker:
-			raise PluginError(u"Duplicate name in TODO keyword list. Please examine `g/b:org_todo_keywords`")
+		flattened_todos = list(it.chain.from_iterable(cleaned_todos))
+		if len(flattened_todos)!=len(set(flattened_todos)):
+			raise PluginError(u"Duplicate names detected in TODO keyword list. Please examine `g/b:org_todo_keywords`")
 		# TODO This is the case when there are 2 todo states with the same
 		# name. It should be handled by making a simple class to hold TODO
 		# states, which would avoid mixing 2 todo states with the same name
@@ -139,7 +133,7 @@ class Todo(object):
 				todo_set[0] for todo_set in enumerate(cleaned_todos)
 				if current_state in todo_set[1]), -1)
 			ind = (top_set + next_dir) % len(cleaned_todos)
-			if ind != len(cleaned_todos)-1:
+			if ind!=len(cleaned_todos)-1:
 				echom("Using set: %s" % str(all_states[ind]))
 			else:
 				echom("Keyword removed.")
@@ -149,7 +143,7 @@ class Todo(object):
 			ind = next((
 				todo_iter[0] for todo_iter in enumerate(flattened_todos)
 				if todo_iter[1] == current_state), -1)
-			return flattened_todos [(ind+next_dir)%len(flattened_todos)]
+			return flattened_todos[(ind+next_dir)%len(flattened_todos)]
 
 	@classmethod
 	@realign_tags

--- a/ftplugin/orgmode/plugins/Todo.py
+++ b/ftplugin/orgmode/plugins/Todo.py
@@ -132,9 +132,7 @@ class Todo(object):
 		# work only with top level index
 		if next_set:
 			top_set = next((todo_set[0] for todo_set in enumerate(cleaned_todos)
-						    if current_state in todo_set[1]), None)
-			if top_set is None:
-				return top_set
+						    if current_state in todo_set[1]), -1)
 			ind = (top_set + next_dir) % len(cleaned_todos)
 			if ind != len(cleaned_todos)-1:
 				echom("Using set: %s" % str(all_states[ind]))
@@ -144,9 +142,7 @@ class Todo(object):
 		# No next set, cycle around everything
 		else:
 			ind = next((todo_iter[0] for todo_iter in enumerate(flattened_todos)
-					    if todo_iter[1] == current_state), None)
-			if ind is None:
-				return ind
+					    if todo_iter[1] == current_state), -1)
 			return flattened_todos [(ind+next_dir)%len(flattened_todos)]
 
 	@classmethod

--- a/ftplugin/orgmode/plugins/Todo.py
+++ b/ftplugin/orgmode/plugins/Todo.py
@@ -102,33 +102,36 @@ class Todo(object):
 			return
 
 		cleaned_todos = [[split_access_key(todo)[0] for todo in
-			  it.chain.from_iterable(x)] for x in all_states]
-		todo_position = [1 if current_state in set else 0 for set in cleaned_todos]
+			  it.chain.from_iterable(x)] for x in all_states]+[[None]]
+		todo_position = [1 if current_state in todo_set else 0 for todo_set in
+						 cleaned_todos]
 		# TODO This is the case when there are 2 todo states with the same
-		# name. It should be handeled by making a simple class to hold TODO
+		# name. It should be handled by making a simple class to hold TODO
 		# states, which would avoid mixing 2 todo states with the same name
 		# since they would have a different reference (but same content),
 		# albeit this can fail because python optimizes short strings (i.e.
 		# they hold the same ref) so care should be taken in implementation
 		if sum(todo_position) > 1:
-			echom("There are 2 todo's with the same name, currently this is not supported")
+			echom("There are 2 todo's with the same name, currently this is not supported. ")
 
 		# backward direction should really be -1 not 2
-		dir = -1 if direction == Direction.BACKWARD else 1
+		next_dir = -1 if direction == Direction.BACKWARD else 1
 		# work only with top level index
 		if next_set:
-			top_set = todo_position.index(1) if sum(todo_position) > 0 else 0
-			ind = (top_set + dir) % len(cleaned_todos)
+			top_set = todo_position.index(1) if sum(todo_position) > 0 else -1
+			ind = (top_set + next_dir) % len(cleaned_todos)
 			echom("Using set: %s" % str(all_states[ind]))
 			return cleaned_todos[ind][0]
 		# No next set, cycle around everything
 		else:
-			tmp = list(it.chain.from_iterable(cleaned_todos)) + [None]
+			tmp = list(it.chain.from_iterable(cleaned_todos))
 			try:
-				ind = (tmp.index(current_state) + dir) % len(tmp)
+				ind = (tmp.index(current_state) + next_dir) % len(tmp)
 			except ValueError:
 				# TODO should this return None or first todo item?
-				ind = 0
+				# Ron: It should return None. Though I doubt it'll ever happen
+				# 	   in real life usage.
+				ind = -1
 			return tmp[ind]
 
 	@classmethod

--- a/tests/test_plugin_todo.py
+++ b/tests/test_plugin_todo.py
@@ -375,12 +375,12 @@ class TodoTestCase(unittest.TestCase):
 		current_state = None
 		result = Todo._get_next_state(current_state, states,
 				Direction.BACKWARD, next_set=True)
-		self.assertEquals(result, None)
+		self.assertEquals(result, u'QA')
 
 		current_state = u'TODO'
 		result = Todo._get_next_state(current_state, states,
 				Direction.BACKWARD, next_set=True)
-		self.assertEquals(result, u'TODO')
+		self.assertEquals(result, None)
 
 		current_state = u'TODO'
 		result = Todo._get_next_state(current_state, states,
@@ -405,12 +405,12 @@ class TodoTestCase(unittest.TestCase):
 		current_state = u'QA'
 		result = Todo._get_next_state(current_state, states,
 				Direction.FORWARD, next_set=True)
-		self.assertEquals(result, u'QA')
+		self.assertEquals(result, None)
 
 		current_state = u'RELEASED'
 		result = Todo._get_next_state(current_state, states,
 				Direction.FORWARD, next_set=True)
-		self.assertEquals(result, u'RELEASED')
+		self.assertEquals(result, None)
 
 		current_state = u'RELEASED'
 		result = Todo._get_next_state(current_state, states,

--- a/tests/test_plugin_todo.py
+++ b/tests/test_plugin_todo.py
@@ -363,7 +363,7 @@ class TodoTestCase(unittest.TestCase):
 		current_state = None
 		result = Todo._get_next_state(current_state, states,
 				Direction.BACKWARD)
-		self.assertEquals(result, u'DONE')
+		self.assertEquals(result, u'RELEASED')
 
 	def test_get_next_keyword_sequence(self):
 		states = [((u'TODO(t)', u'NEXT(n)', u'NOW(w)'), (u'DELEGATED(g)', u'DONE(d)')), ((u'QA(q)', ), (u'RELEASED(r)', ))]


### PR DESCRIPTION
- Separated the keyword list validity checking and processing`Todo._process_all_states` from `Todo._get_next_state`
- Unified the cycling behaviour of `next_set` being `True` and 'False': `None` lead to first state of the cycling, last state of the cycling lead to `None`.
- Adjusted the test according to:

> - Before cycling, appending `[[None]]` after the final set, and treat it as
>   an independent set of states.
> - If `next_set` is True, then jump the next set directly. No matter FORWARD
>   or BACKWARD, return the first state of the corresponding set.
> - If `next_set` is false, treating the entire state set as a flat list and
>   cycling through.

Also, I refined your code on `flatten_list()` a bit, in `ftplugin/orgmode/liborgmode/base.py`.
